### PR TITLE
Upgrade StrongSwan 5.9.5

### DIFF
--- a/strongswan/Dockerfile
+++ b/strongswan/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 MAINTAINER Andreas Steffen <andreas.steffen@strongswan.org>
-ENV VERSION="5.9.4"
+ENV VERSION="5.9.5"
 
 RUN \
   # install packages

--- a/strongswan/Dockerfile
+++ b/strongswan/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 MAINTAINER Andreas Steffen <andreas.steffen@strongswan.org>
-ENV VERSION="5.9.5"
+ENV VERSION="5.9.5" MD5SUM="53005324e3cba8592f1fb958b1c2d0e5"
 
 RUN \
   # install packages
@@ -12,6 +12,7 @@ RUN \
   mkdir /strongswan-build && \
   cd /strongswan-build && \
   wget https://download.strongswan.org/strongswan-$VERSION.tar.bz2 && \
+  echo "${MD5SUM} strongswan-${VERSION}.tar.bz2" | md5sum --check --strict && \
   tar xfj strongswan-$VERSION.tar.bz2 && \
   cd strongswan-$VERSION && \
   ./configure --prefix=/usr --sysconfdir=/etc --disable-defaults      \

--- a/strongswan/docker-compose.yml
+++ b/strongswan/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   vpn-server:
-    image: strongx509/strongswan:5.9.4
+    image: strongx509/strongswan:5.9.5
     container_name: vpn-server
     cap_add:
       - NET_ADMIN
@@ -19,7 +19,7 @@ services:
       intranet:
          ipv4_address: 10.1.0.2
   vpn-client:
-    image: strongx509/strongswan:5.9.4
+    image: strongx509/strongswan:5.9.5
     container_name: vpn-client
     depends_on:
       - vpn-server


### PR DESCRIPTION
https://www.strongswan.org/blog/2022/01/24/strongswan-5.9.5-released.html

Also add a `md5sum --check` for the download.

The md5 checksum for the `.tar.bz2` file on the https://www.strongswan.org/download.html HTML page is invalid: it appears to have an extra leading `9` digit, but is otherwise valid.