### PR TITLE
Update Dockerfile for LibOQS to Fix KyberSlash vulnerability

### DIFF
--- a/pq-strongswan/Dockerfile
+++ b/pq-strongswan/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 MAINTAINER Andreas Steffen <andreas.steffen@strongswan.org>
-ENV VERSION="6.0.0beta5"
-ENV LIBOQS_VERSION="0.9.0"
+ENV VERSION="6.0.0beta6"
+ENV LIBOQS_VERSION="0.9.2"
 
 RUN \
   # install packages


### PR DESCRIPTION
Update LibOQS to 0.9.2 to fix Kyberslash (https://kyberslash.cr.yp.to/)